### PR TITLE
MSmedia, MSmodel, rast_client, rpcclient, and template

### DIFF
--- a/modelseedpy/core/msmedia.py
+++ b/modelseedpy/core/msmedia.py
@@ -3,7 +3,7 @@ from cobra.core.dictlist import DictList
 
 logger = logging.getLogger(__name__)
 
-class MediaCompound:
+class MediaCompound: 
 
     def __init__(self, compound_id, lower_bound, upper_bound, concentration=None):
         self.id = compound_id
@@ -14,37 +14,32 @@ class MediaCompound:
     @property
     def maxFlux(self):
         # TODO: will be removed later just for old methods
-        return -1 * self.lower_bound
+        return -self.lower_bound
 
     @property
     def minFlux(self):
         # TODO: will be removed later just for old methods
-        return -1 * self.upper_bound
+        return -self.upper_bound
 
 
 class MSMedia:
-
     def __init__(self, media_id):
         self.id = media_id
         self.mediacompounds = DictList()
 
     @staticmethod
-    def from_dict(d):
+    def from_dict(media_dict):
         """
         Either dict with exchange bounds (example: {'cpd00027': (-10, 1000)}) or
         just absolute value of uptake (example: {''cpd00027': 10})
-        :param d:
-        :return:
         """
         media = MSMedia('media')
         media_compounds = []
-        for cpd_id in d:
-            v = d[cpd_id]
-            if type(v) is tuple:
+        for cpd_id, v in media_dict.items():
+            if isinstance(v, tuple):
                 media_compounds.append(MediaCompound(cpd_id, v[0], v[1]))
             else:
-                media_compounds.append(MediaCompound(cpd_id, -1 * v, 1000))
-
+                media_compounds.append(MediaCompound(cpd_id, -v, 1000))
         media.mediacompounds += media_compounds
         return media
 
@@ -61,13 +56,12 @@ class MSMedia:
             if cmp is not None:
                 met_id += '_' + cmp
             media[met_id] = (compound.lower_bound, compound.upper_bound)
-
         return media
     
     def merge(self,media,overwrite_overlap=False):
         new_cpds = []
         for cpd in media.mediacompounds:
-            newcpd = MediaCompound(cpd.id,-1*cpd.maxFlux,-1*cpd.minFlux,cpd.concentration)
+            newcpd = MediaCompound(cpd.id, -cpd.maxFlux, -cpd.minFlux, cpd.concentration)
             if newcpd.id in self.mediacompounds:
                 if overwrite_overlap:
                     self.mediacompounds[newcpd.id] = newcpd

--- a/modelseedpy/core/msmedia.py
+++ b/modelseedpy/core/msmedia.py
@@ -3,7 +3,7 @@ from cobra.core.dictlist import DictList
 
 logger = logging.getLogger(__name__)
 
-class MediaCompound: 
+class MediaCompound:
 
     def __init__(self, compound_id, lower_bound, upper_bound, concentration=None):
         self.id = compound_id
@@ -32,6 +32,8 @@ class MSMedia:
         """
         Either dict with exchange bounds (example: {'cpd00027': (-10, 1000)}) or
         just absolute value of uptake (example: {''cpd00027': 10})
+        :param d:
+        :return:
         """
         media = MSMedia('media')
         media_compounds = []

--- a/modelseedpy/core/msmodel.py
+++ b/modelseedpy/core/msmodel.py
@@ -67,6 +67,11 @@ def split_compartment_from_index(cmp_str: str):
 
 
 def get_cmp_token(compartments):
+    """
+    
+    :param compartments:
+    :return:
+    """
     if len(compartments) == 0:
         logger.warning('The compartments parameter is empty. The "c" parameter is assumed.')
         return 'c'

--- a/modelseedpy/core/msmodel.py
+++ b/modelseedpy/core/msmodel.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 def get_reaction_constraints_from_direction(direction: str) -> (float, float):
     """
     Converts direction symbols ( > or <) to lower and upper bound, any other value is returned as reversible bounds
+    :param direction:
+    :return:
     """
     if direction == '>':
         return 0, 1000
@@ -18,16 +20,15 @@ def get_reaction_constraints_from_direction(direction: str) -> (float, float):
         return -1000, 1000
 
 
-def get_direction_from_constraints(lower_bound, upper_bound):
-    if lower_bound < 0 < upper_bound:
+def get_direction_from_constraints(lower, upper):
+    if lower < 0 < upper:
         return '='
-    elif upper_bound > 0:
+    elif upper > 0:
         return '>'
-    elif lower_bound < 0:
+    elif lower < 0:
         return '<'
-    else:
-        logger.error(f'The [{lower_bound}, {upper_bound}] bounds are not amenable with a direction string.')
-        return '?'
+    logger.error(f'The [{lower}, {upper}] bounds are not amenable with a direction string.')
+    return '?'
 
 def get_gpr_string(gpr):
     ors = []
@@ -87,14 +88,14 @@ def get_cmp_token(compartments):
 
 def get_set_set(expr_str):
     if len(expr_str.strip()) == 0:
-        return set()
+        return {}
     expr_str = expr_str.replace(' or ', ' | ')
     expr_str = expr_str.replace(' and ', ' & ')
     dnf = expr(expr_str).to_dnf()
     if len(dnf.inputs) == 1 or dnf.NAME == 'And':
         return {frozenset({str(x) for x in dnf.inputs})}
     else:
-        return {frozenset({str(x) for x in o.inputs}) for o in dnf.xs}  
+        return {frozenset({str(x) for x in o.inputs}) for o in dnf.xs}
 
 
 class MSModel(Model):

--- a/modelseedpy/core/msmodel.py
+++ b/modelseedpy/core/msmodel.py
@@ -86,7 +86,7 @@ def get_cmp_token(compartments):
     return None
 
 
-def get_set_set(expr_str):
+def get_set_set(expr_str):   # !!! this currently returns dictionaries, not sets??
     if len(expr_str.strip()) == 0:
         return {}
     expr_str = expr_str.replace(' or ', ' | ')

--- a/modelseedpy/core/msmodel.py
+++ b/modelseedpy/core/msmodel.py
@@ -68,7 +68,7 @@ def split_compartment_from_index(cmp_str: str):
 
 def get_cmp_token(compartments):
     """
-    
+
     :param compartments:
     :return:
     """

--- a/modelseedpy/core/rast_client.py
+++ b/modelseedpy/core/rast_client.py
@@ -1,7 +1,6 @@
 from modelseedpy.core.rpcclient import RPCClient
-from modelseedpy.core.msgenome import MSFeature
 import re
-from modelseedpy.core.msgenome import MSGenome, read_fasta, normalize_role #move this to this lib
+from modelseedpy.core.msgenome import MSGenome, normalize_role #move this to this lib
 
 ### delete this after ####
 def aux_rast_result(res, g):

--- a/modelseedpy/core/rast_client.py
+++ b/modelseedpy/core/rast_client.py
@@ -1,6 +1,7 @@
 from modelseedpy.core.rpcclient import RPCClient
+from modelseedpy.core.msgenome import MSFeature   # !!! import is never used
 import re
-from modelseedpy.core.msgenome import MSGenome, normalize_role #move this to this lib
+from modelseedpy.core.msgenome import MSGenome, read_fasta, normalize_role #move this to this lib     # !!! read_fasta is never used
 
 ### delete this after ####
 def aux_rast_result(res, g):

--- a/modelseedpy/core/rpcclient.py
+++ b/modelseedpy/core/rpcclient.py
@@ -15,21 +15,18 @@ class _JSONObjectEncoder(_json.JSONEncoder):
         return _json.JSONEncoder.default(self, obj)
 
 class ServerError(Exception):
-
-    def __init__(self, name, code, message, data=None, error=None):
+    def __init__(self, name, code, message = None, data=None, error=None):
         super(Exception, self).__init__(message)
         self.name = name
         self.code = code
-        self.message = '' if message is None else message
+        self.message = message or '' 
         self.data = data or error or ''
         # data = JSON RPC 2.0, error = 1.1
-
     def __str__(self):
-        return self.name + ': ' + str(self.code) + '. ' + self.message + \
-            '\n' + self.data
+        return self.name + ': ' + str(self.code) + '. ' + self.message + '\n' + self.data
 
 class RPCClient:
-    def __init__(self,url,token=None,version="1.0",timeout=30 * 60,trust_all_ssl_certificates=False):
+    def __init__(self, url, token=None, version="1.0", timeout=30*60, trust_all_ssl_certificates=False):
         self.url = url
         self.token = token
         self.version = version
@@ -38,20 +35,17 @@ class RPCClient:
     
     def call(self,method,params,token=None):
         headers = {}
-        if token != None:
+        if token:
             headers['AUTHORIZATION'] = token
-        elif self.token != None:
-            headers['AUTHORIZATION'] = token
-        arg_hash = {'method': method,
-            'params': params,
-            'version': self.version,
-            'id': str(_random.random())[2:],
-            'context': {}
+        elif self.token:
+            headers['AUTHORIZATION'] = self.token
+        arg_hash = {
+            'method': method, 'params': params, 'context': {},
+            'version': self.version, 'id': str(_random.random())[2:]
            }
         body = _json.dumps(arg_hash, cls=_JSONObjectEncoder)
-        ret = _requests.post(self.url, data=body, headers=headers,
-             timeout=self.timeout,
-             verify=not self.trust_all_ssl_certificates)
+        ret = _requests.post(
+            self.url, data=body, headers=headers,timeout=self.timeout, verify=not self.trust_all_ssl_certificates)
         ret.encoding = 'utf-8'
         if ret.status_code == 500:
             if ret.headers.get('content-type') == 'application/json':

--- a/modelseedpy/core/rpcclient.py
+++ b/modelseedpy/core/rpcclient.py
@@ -39,13 +39,16 @@ class RPCClient:
             headers['AUTHORIZATION'] = token
         elif self.token:
             headers['AUTHORIZATION'] = self.token
-        arg_hash = {
-            'method': method, 'params': params, 'context': {},
-            'version': self.version, 'id': str(_random.random())[2:]
+        arg_hash = {'method': method,
+            'params': params,
+            'version': self.version,
+            'id': str(_random.random())[2:],
+            'context': {}
            }
         body = _json.dumps(arg_hash, cls=_JSONObjectEncoder)
-        ret = _requests.post(
-            self.url, data=body, headers=headers,timeout=self.timeout, verify=not self.trust_all_ssl_certificates)
+        ret = _requests.post(self.url, data=body, headers=headers,
+             timeout=self.timeout,
+             verify=not self.trust_all_ssl_certificates)
         ret.encoding = 'utf-8'
         if ret.status_code == 500:
             if ret.headers.get('content-type') == 'application/json':

--- a/modelseedpy/core/template.py
+++ b/modelseedpy/core/template.py
@@ -1,6 +1,8 @@
 import logging
 logger = logging.getLogger(__name__)
 
+import re  # !!! import never used
+import copy  # !!! import never used
 from cobra.core.dictlist import DictList
 from cobra.core.model import Metabolite, Reaction
 
@@ -9,9 +11,9 @@ class Template():
         self.compounds, self.compcompounds, self.reactions = DictList(), DictList(), DictList()
         
     def convert_template_compound(self,cpdid,index):
+        comp_compound = self.compcompounds.get_by_id(cpdid)
         base_id = cpdid.split("_")[0]
-        comp_compound = self.compcompounds.get_by_id(base_id)
-        base_compound = self.compounds.get_by_id(cpdid.split("_")[0])
+        base_compound = self.compounds.get_by_id(base_id)
         compartment = comp_compound.templatecompartment_ref.split("/").pop() + str(index)
         new_id = base_compound.id + str(index)
         met = Metabolite(new_id, formula=base_compound.formula, name=base_compound.name, 

--- a/modelseedpy/core/template.py
+++ b/modelseedpy/core/template.py
@@ -9,14 +9,15 @@ class Template():
         self.compounds, self.compcompounds, self.reactions = DictList(), DictList(), DictList()
         
     def convert_template_compound(self,cpdid,index):
-        comp_compound = self.compcompounds.get_by_id(cpdid)
+        base_id = cpdid.split("_")[0]
+        comp_compound = self.compcompounds.get_by_id(base_id)
         base_compound = self.compounds.get_by_id(cpdid.split("_")[0])
         compartment = comp_compound.templatecompartment_ref.split("/").pop() + str(index)
         new_id = base_compound.id + str(index)
         met = Metabolite(new_id, formula=base_compound.formula, name=base_compound.name, 
             charge=comp_compound.charge, compartment=compartment)
         met.annotation["sbo"] = "SBO:0000247" #simple chemical - Simple, non-repetitive chemical entity.
-        met.annotation["seed.compound"] = cpdid.split("_")[0]
+        met.annotation["seed.compound"] = base_id
         return met
     
     def convert_template_reaction(self,model,rxnid,index,for_gapfilling=True):   

--- a/modelseedpy/core/template.py
+++ b/modelseedpy/core/template.py
@@ -1,59 +1,45 @@
 import logging
-
-import re
-import copy
-from cobra.core.dictlist import DictList
-
 logger = logging.getLogger(__name__)
 
-class Template():
+from cobra.core.dictlist import DictList
+from cobra.core.model import Metabolite, Reaction
 
+class Template():
     def __init__(self):
-        self.compounds = DictList()
-        self.compcompounds = DictList()
-        self.reactions = DictList()
+        self.compounds, self.compcompounds, self.reactions = DictList(), DictList(), DictList()
         
     def convert_template_compound(self,cpdid,index):
         comp_compound = self.compcompounds.get_by_id(cpdid)
-        base_id = cpdid.split("_")[0]
-        base_compound = self.compounds.get_by_id(base_id)
-        compartment = comp_compound.templatecompartment_ref.split("/").pop()
-        compartment += str(index)
-        new_id = template_compound.id
-        new_id += str(index)
-        met = Metabolite(
-            new_id, 
-            formula=base_compound.formula, 
-            name=base_compound.name, 
-            charge=comp_compound.charge, 
-            compartment=compartment)
+        base_compound = self.compounds.get_by_id(cpdid.split("_")[0])
+        compartment = comp_compound.templatecompartment_ref.split("/").pop() + str(index)
+        new_id = base_compound.id + str(index)
+        met = Metabolite(new_id, formula=base_compound.formula, name=base_compound.name, 
+            charge=comp_compound.charge, compartment=compartment)
         met.annotation["sbo"] = "SBO:0000247" #simple chemical - Simple, non-repetitive chemical entity.
-        met.annotation["seed.compound"] = base_id
+        met.annotation["seed.compound"] = cpdid.split("_")[0]
         return met
     
-    def convert_template_reaction(self,model,rxnid,index,for_gapfilling=1):   
+    def convert_template_reaction(self,model,rxnid,index,for_gapfilling=True):   
         template_reaction = self.reactions.get_by_id(rxnid)
-        array = template_reaction["id"].split("_")
-        base_id = array[0]
-        new_id = template_reaction["id"]
-        new_id += str(index)
+        base_id = template_reaction["id"].split("_")[0]
+        new_id = template_reaction["id"] + str(index)
 
         lower_bound = template_reaction["maxrevflux"]
         upper_bound = template_reaction["maxforflux"]
 
         direction = template_reaction["GapfillDirection"]
-        if for_gapfilling == 0:
+        if not for_gapfilling:
             direction = template_reaction["direction"]
-
         if direction == ">":
             lower_bound = 0
         elif direction == "<":
             upper_bound = 0
 
-        cobra_reaction = Reaction(new_id, 
-                                  name=template_reaction["name"], 
-                                  lower_bound=lower_bound, 
-                                  upper_bound=upper_bound)
+        cobra_reaction = Reaction(
+            new_id, 
+            name=template_reaction["name"], 
+            lower_bound=lower_bound, 
+            upper_bound=upper_bound)
 
         object_stoichiometry = {}
         for item in template_reaction["templateReactionReagents"]:


### PR DESCRIPTION
Hello @Fxe ,

Here are a few edits and error corrections to MSmedia, MSmodel, rast_client, rpcclient, and template.
MSmedia:

1) negative values are prefixed directly to values
2) generic argument names were clarified
3) items() simplified a for loop

MSmodel:

1) pyeda is imported, with a comment for Windows users (for whom the import was originally commented). This prevents a `ModelNotFoundError` later in the code when `pyeda` is called by never imported.
2) Error messages were clarified
3) the empty argument catch of `get_set_set` was moved to the beginning of the function, to save unnecessary computation.
4) `replace` returns the original string if the sought character is not found, so the logic was simplified
5) a possible error with  `get_set_set` is flagged, where its named suggests that it returns a set but it actually returns a dictionary.

rast_client:

1) unused imports are flagged

rpcclient:

1) an in-line conditional was simplified
2) the second condition of `call`, where `self.token` is not None, is corrected to use `self.token` instead of `token`, which in the previous condition was determined to be None.

template:

1) unused imports were flagged
2) variable definitions are condensed
3) 1/0 boolean logic, not involving KBase objects, is replaced with True/False



I can clarify or discuss any changes.

  Thank you so much :)
       Andrew