### PR TITLE
Minor Fixes to get Actions to work

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,4 +19,7 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Set file mode to false
+        run: |
+          git config core.filemode false
       - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
There's a bit of a chicken and egg problem with setting up GitHub Actions.

Creating actions in a fork doesn't necessarily tell GitHub to run those actions until the action lands in a protected branch.

So, this commit verifies some of the local development environment and makes sure the pipeline is in alignment.

Set `git config core.filemode false` this tells git and the pre-commit check to use it's internal state for the file mode rather than the file system.

Also, pre-commit doesn't seem to support Python 3.6 anymore. So, moved the support up to Python 3.8+